### PR TITLE
loki: its now possible to use bucketnames

### DIFF
--- a/loki/README.md
+++ b/loki/README.md
@@ -15,8 +15,3 @@ This setup uses the new boltdb-shipper shipped with Loki 2.0.0.
   - ruler: alerting [info](https://grafana.com/docs/loki/latest/rules/)
     This application includes a sidecar that picks up rules from kubernetes `ConfigMap` with the label `loki_rule` set.
   - table-manager: (not used)
-
-
-## Config
-
-For AWS IAM roles for service accounts (IRSA) to work, it's important that the `.WithCredentials` method is never called https://github.com/grafana/loki/blob/8c1fe88409fe832b45da1f8f3cdd8116d81f4048/vendor/github.com/cortexproject/cortex/pkg/chunk/aws/s3_storage_client.go#L133. This means you need to pass an s3 url.

--- a/loki/files/config.yaml
+++ b/loki/files/config.yaml
@@ -108,7 +108,8 @@ server:
   http_server_write_timeout: 1m
 storage_config:
   aws:
-    s3: s3:///${LOKI_STORAGE_CONFIG_AWS_BUCKETNAMES}
+    s3: s3:///
+    bucketnames: ${LOKI_STORAGE_CONFIG_AWS_BUCKETNAMES}
     sse_encryption: true
   boltdb_shipper:
     shared_store: aws


### PR DESCRIPTION
https://github.com/grafana/loki/issues/3069 is partially addressed;
however an empty S3 url is still required to avoid loki reaching out to sts.dummy.amazonaws.com