### PR TITLE
loki: default value syntax is ${env_var:-default} with a hyphen

### DIFF
--- a/loki/files/config.yaml
+++ b/loki/files/config.yaml
@@ -50,7 +50,7 @@ limits_config:
   ingestion_rate_mb: 10
   ingestion_rate_strategy: global
   max_cache_freshness_per_query: 10m
-  max_concurrent_tail_requests: ${LOKI_LIMITS_CONFIG_MAX_CONCURRENT_TAIL_REQUESTS:100}
+  max_concurrent_tail_requests: ${LOKI_LIMITS_CONFIG_MAX_CONCURRENT_TAIL_REQUESTS:-100}
   max_global_streams_per_user: 10000
   max_query_length: 12000h
   max_query_parallelism: 16


### PR DESCRIPTION
Contrary to [loki documentation](https://grafana.com/docs/loki/latest/configuration/#use-environment-variables-in-the-configuration)

---

I noticed that we've been hitting max number of tails a lot lately; checking out the live config (e.g. `kubectl exec -it deploy/query-frontend -- wget -O- http://localhost:3100/config`) I saw that `max_concurrent_tail_requests` was `0` rather than the expected `100`. Adding a hyphen to the syntax (which is how default values work in bash) made the config value `100` as desired.

As a follow-up, this issue should be reported to loki upstream.