### PR TITLE
loki: increase ingester limits

### DIFF
--- a/loki/files/config.yaml
+++ b/loki/files/config.yaml
@@ -46,8 +46,8 @@ ingester_client:
   remote_timeout: 1s
 limits_config:
   enforce_metric_name: false
-  ingestion_burst_size_mb: 20
-  ingestion_rate_mb: 10
+  ingestion_burst_size_mb: 30
+  ingestion_rate_mb: 15
   ingestion_rate_strategy: global
   max_cache_freshness_per_query: 10m
   max_concurrent_tail_requests: ${LOKI_LIMITS_CONFIG_MAX_CONCURRENT_TAIL_REQUESTS:-100}


### PR DESCRIPTION
The promtail pod in charge of ingesting logs from the platform-mongo primary looks like it's being rate limited:

`
server returned HTTP status 429 Too Many Requests (429): Ingestion rate limit exceeded (limit: 3495253 bytes/sec) while attempting to ingest '696' lines totaling '1048147' bytes, reduce log volume or contact your Loki administrator to see if the limit can be increased
`

MongoDB is extremely verbose in its log output, even on the lowest setting.