### PR TITLE
loki: introduce env vars to override ingester limits

### DIFF
--- a/loki/files/config.yaml
+++ b/loki/files/config.yaml
@@ -46,8 +46,8 @@ ingester_client:
   remote_timeout: 1s
 limits_config:
   enforce_metric_name: false
-  ingestion_burst_size_mb: 30
-  ingestion_rate_mb: 15
+  ingestion_burst_size_mb: ${LOKI_LIMITS_CONFIG_INGESTION_BURST_SIZE_MB:-20}
+  ingestion_rate_mb: ${LOKI_LIMITS_CONFIG_INGESTION_RATE_MB:-10}
   ingestion_rate_strategy: global
   max_cache_freshness_per_query: 10m
   max_concurrent_tail_requests: ${LOKI_LIMITS_CONFIG_MAX_CONCURRENT_TAIL_REQUESTS:-100}


### PR DESCRIPTION
Reintroduce the old default values, which are from the loki team recommended config:
https://github.com/grafana/loki/blob/e16f1fef81e199d25e5cb43b6f285750dd0cb35f/production/ksonnet/loki/config.libsonnet#L196-L197