### PR TITLE
loki: querier, add ability to adjust loki querier timeout

### DIFF
--- a/loki/files/config.yaml
+++ b/loki/files/config.yaml
@@ -65,6 +65,7 @@ memberlist:
     - ruler
 querier:
   query_ingesters_within: 2h
+  query_timeout: ${LOKI_QUERIER_CONFIG_QUERY_TIMEOUT:100s}
 query_range:
   align_queries_with_step: true
   cache_results: true


### PR DESCRIPTION
Add ability to change this setting via envvar. 

Default value is 60s: https://grafana.com/docs/loki/latest/configuration/#querier_config