### PR TITLE
loki: use index-gateway

### DIFF
--- a/loki/README.md
+++ b/loki/README.md
@@ -9,6 +9,7 @@ This setup uses the new boltdb-shipper shipped with Loki 2.0.0.
 
   - compactor: (optional) BoltDB Shipper specific service [docs](https://github.com/grafana/loki/blob/master/docs/sources/operations/storage/boltdb-shipper.md#compactor)
   - distributor: validates incoming logs and sends to ingester
+  - index-gateway: synchronizes the BoltDB index from the Object Storage in order to serve index queries to the Queriers and Rulers over gRPC
   - ingester: writes logs to backing store
   - query-frontend: (optional) [info](https://github.com/grafana/loki/blob/master/docs/sources/architecture/_index.md#query-frontend)
   - querier: performs the queries

--- a/loki/index-gateway/apps-v1.StatefulSet-index-gateway.yaml
+++ b/loki/index-gateway/apps-v1.StatefulSet-index-gateway.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: index-gateway
+  labels:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/component: index-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/component: index-gateway
+  serviceName: index-gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/component: index-gateway
+    spec:
+      containers:
+      - name: index-gateway
+        args:
+        - -boltdb.shipper.cache-location=/data/boltdb-cache
+        - -config.expand-env
+        - -config.file=/etc/loki/config/config.yaml
+        - -target=index-gateway
+        envFrom:
+        - configMapRef:
+            name: loki-env-vars
+            optional: true
+        - secretRef:
+            name: loki-env-vars
+            optional: true
+        image: grafana/loki
+        ports:
+        - containerPort: 3100
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 3100
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 500m
+            memory: 2Gi
+        volumeMounts:
+        - mountPath: /data
+          name: index-gateway-data
+        - mountPath: /etc/loki/config
+          name: loki
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+      serviceAccount: loki
+      volumes:
+      - configMap:
+          name: loki
+        name: loki
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      name: index-gateway-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi

--- a/loki/index-gateway/kustomization.yaml
+++ b/loki/index-gateway/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - apps-v1.StatefulSet-index-gateway.yaml
+  - v1.Service-index-gateway.yaml
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: StatefulSet
+      name: querier
+    path: querier-kind.patch.yaml
+    options:
+      allowKindChange: true
+  - target:
+      group: apps
+      version: v1
+      name: querier
+    path: server-address.patch.yaml
+  - target:
+      group: apps
+      version: v1
+      name: ruler
+    path: server-address.patch.yaml

--- a/loki/index-gateway/querier-kind.patch.yaml
+++ b/loki/index-gateway/querier-kind.patch.yaml
@@ -1,0 +1,18 @@
+# When running queriers with index-gateway, they no longer need their own storage
+# and hence can be swapped out for a Deployment
+- op: replace
+  path: /kind
+  value: Deployment
+- op: remove
+  path: /spec/podManagementPolicy
+- op: add
+  path: /spec/minReadySeconds
+  value: 10
+- op: remove
+  path: /spec/serviceName
+- op: remove
+  path: /spec/template/spec/containers/0/volumeMounts/0
+- op: remove
+  path: /spec/updateStrategy
+- op: remove
+  path: /spec/volumeClaimTemplates

--- a/loki/index-gateway/server-address.patch.yaml
+++ b/loki/index-gateway/server-address.patch.yaml
@@ -1,0 +1,6 @@
+- op: test
+  path: /spec/template/spec/containers/0/args/0
+  value: -boltdb.shipper.cache-location=/data/boltdb-cache
+- op: replace
+  path: /spec/template/spec/containers/0/args/0
+  value: -boltdb.shipper.index-gateway-client.server-address=dns:///index-gateway:9095

--- a/loki/index-gateway/v1.Service-index-gateway.yaml
+++ b/loki/index-gateway/v1.Service-index-gateway.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: index-gateway
+  labels:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/component: index-gateway
+spec:
+  ports:
+  - name: index-gateway-http-metrics
+    port: 3100
+    targetPort: 3100
+  - name: index-gateway-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/component: index-gateway

--- a/loki/kustomization.yaml
+++ b/loki/kustomization.yaml
@@ -25,6 +25,7 @@ resources:
   - alerting-rules.yaml
   - recording-rules.yaml
 components:
+  - ./index-gateway
   - ./ruler-sidecar
 configMapGenerator:
   - name: loki


### PR DESCRIPTION
As mentioned in #11 

From Loki 2.3.0 release notes:
> We created an index gateway which takes on the task of downloading the boltdb-shipper index files allowing you to run your queriers without any local disk requirements, this is really helpful in Kubernetes environments where you can return your queriers from Statefulsets back to Deployments and save a lot of PVC costs and operational headaches.

There's not many docs available right now; there's a little mentioned at https://grafana.com/docs/loki/latest/operations/storage/boltdb-shipper/#index-gateway