### PR TITLE
loki: default remote_client client url to the empty string

### DIFF
--- a/loki/files/config.yaml
+++ b/loki/files/config.yaml
@@ -89,7 +89,7 @@ ruler:
   remote_write:
     enabled: ${LOKI_RULER_REMOTE_WRITE_ENABLED:-false}
     client:
-      url: ${LOKI_RULER_REMOTE_WRITE_CLIENT_URL}
+      url: ${LOKI_RULER_REMOTE_WRITE_CLIENT_URL:-""}
   ring:
     kvstore:
       store: memberlist


### PR DESCRIPTION
See https://github.com/grafana/loki/issues/4136