### PR TITLE
loki: fix invalid env var expansion

### DIFF
--- a/loki/files/config.yaml
+++ b/loki/files/config.yaml
@@ -66,7 +66,7 @@ querier:
     # Default to 400 days retention.
     max_look_back_period: 9600h
   query_ingesters_within: 2h
-  query_timeout: ${LOKI_QUERIER_QUERY_TIMEOUT:60s}
+  query_timeout: ${LOKI_QUERIER_QUERY_TIMEOUT:-60s}
 query_range:
   align_queries_with_step: true
   cache_results: true


### PR DESCRIPTION
The syntax is `:-` rather than `:`.

i.e. https://github.com/BitGo/kustomize-loki/pull/4 all over again

Introduced in https://github.com/BitGo/kustomize-loki/pull/17/