### PR TITLE
fix: add recording rule that is used in loki-operational dashboard

### DIFF
--- a/promtail/recording-rules.yaml
+++ b/promtail/recording-rules.yaml
@@ -44,3 +44,5 @@ spec:
       record: job_status_code_namespace:promtail_request_duration_seconds_sum:sum_rate
     - expr: sum(rate(promtail_request_duration_seconds_count[1m])) by (job, status_code, namespace)
       record: job_status_code_namespace:promtail_request_duration_seconds_count:sum_rate
+    - expr: sum(rate(container_cpu_usage_seconds_total)[1m]) 
+      record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate


### PR DESCRIPTION
loki-operational-dashboard uses recording rule that we don't have, adding it