### PR TITLE
loki/ingress: expose ruler API

### DIFF
--- a/loki/ingress/ingress.yaml
+++ b/loki/ingress/ingress.yaml
@@ -43,6 +43,13 @@ spec:
             name: querier
             port:
               number: 3100
+      - path: /loki/api/v1/rules
+        pathType: Prefix
+        backend:
+          service:
+            name: ruler
+            port:
+              number: 3100
       - path: /loki/api
         pathType: Prefix
         backend:


### PR DESCRIPTION
From https://grafana.com/docs/loki/latest/api/#ruler:
> This experimental endpoint is disabled by default and can be enabled via the -experimental.ruler.enable-api CLI flag or the YAML config option.

Not sure if we should merge this now or wait for the API to be made stable.... 