### PR TITLE
loki: disable the change of querier kind until kustomize bug is fixed

### DIFF
--- a/loki/index-gateway/querier-kind.patch.yaml
+++ b/loki/index-gateway/querier-kind.patch.yaml
@@ -1,18 +1,21 @@
 # When running queriers with index-gateway, they no longer need their own storage
-# and hence can be swapped out for a Deployment
-- op: replace
-  path: /kind
-  value: Deployment
-- op: remove
-  path: /spec/podManagementPolicy
-- op: add
-  path: /spec/minReadySeconds
-  value: 10
-- op: remove
-  path: /spec/serviceName
 - op: remove
   path: /spec/template/spec/containers/0/volumeMounts/0
 - op: remove
-  path: /spec/updateStrategy
-- op: remove
   path: /spec/volumeClaimTemplates
+
+# Now that we don't need storage, there's no need for this to be a StatefulSet
+# -> swap kind for a Deployment
+# XXX: Disabled the `kind` change due to https://github.com/kubernetes-sigs/kustomize/issues/4136
+# - op: replace
+#   path: /kind
+#   value: Deployment
+# - op: remove
+#   path: /spec/podManagementPolicy
+# - op: add
+#   path: /spec/minReadySeconds
+#   value: 10
+# - op: remove
+#   path: /spec/serviceName
+# - op: remove
+#   path: /spec/updateStrategy


### PR DESCRIPTION
Workaround until https://github.com/kubernetes-sigs/kustomize/issues/4136 is fixed.
Even after it is fixed we'll need to bump the minimum required kustomize version; so could be non-trivial.

Fixes #27