### PR TITLE
loki: fix invalid recording rule

### DIFF
--- a/loki/recording-rules.yaml
+++ b/loki/recording-rules.yaml
@@ -44,5 +44,5 @@ spec:
       record: namespace_job_route:loki_request_duration_seconds_sum:sum_rate
     - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (namespace, job, route)
       record: namespace_job_route:loki_request_duration_seconds_count:sum_rate
-    - expr: sum(rate(container_cpu_usage_seconds_total)[1m]) by (pod,container)
+    - expr: sum(rate(container_cpu_usage_seconds_total[1m])) by (pod, container)
       record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate


### PR DESCRIPTION
Reported via @RyanSquared  at https://github.com/BitGo/kustomize-loki/commit/c9cd5c2ec4254142a4d2caa80d9a07b7a41d4866#commitcomment-55914056; thankyou!

Before:
```
$ yq .spec loki/recording-rules.yaml > tmp.yaml
$ cortextool rules check --log.level=debug tmp.yaml 
INFO[0000] log level set to debug                       
ERRO[0000] unable parse rules file                       error="79:19: group \"loki.rules\", rule 18, \"node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate\": could not parse expression: 1:44: parse error: ranges only allowed for vector selectors" file=tmp.yaml
cortextool: error: check operation unsuccessful, unable to parse rules files: file read error, try --help
```

After:
```
$ yq .spec loki/recording-rules.yaml > tmp.yaml
$ cortextool rules check --log.level=debug tmp.yaml 
INFO[0000] log level set to debug                       
DEBU[0000] linting recording rule name                   rule="job:loki_request_duration_seconds:99quantile"
DEBU[0000] linting recording rule name                   rule="job:loki_request_duration_seconds:50quantile"
DEBU[0000] linting recording rule name                   rule="job:loki_request_duration_seconds:avg"
DEBU[0000] linting recording rule name                   rule="job:loki_request_duration_seconds_bucket:sum_rate"
DEBU[0000] linting recording rule name                   rule="job:loki_request_duration_seconds_sum:sum_rate"
DEBU[0000] linting recording rule name                   rule="job:loki_request_duration_seconds_count:sum_rate"
DEBU[0000] linting recording rule name                   rule="job_route:loki_request_duration_seconds:99quantile"
DEBU[0000] linting recording rule name                   rule="job_route:loki_request_duration_seconds:50quantile"
DEBU[0000] linting recording rule name                   rule="job_route:loki_request_duration_seconds:avg"
DEBU[0000] linting recording rule name                   rule="job_route:loki_request_duration_seconds_bucket:sum_rate"
DEBU[0000] linting recording rule name                   rule="job_route:loki_request_duration_seconds_sum:sum_rate"
DEBU[0000] linting recording rule name                   rule="job_route:loki_request_duration_seconds_count:sum_rate"
DEBU[0000] linting recording rule name                   rule="namespace_job_route:loki_request_duration_seconds:99quantile"
DEBU[0000] linting recording rule name                   rule="namespace_job_route:loki_request_duration_seconds:50quantile"
DEBU[0000] linting recording rule name                   rule="namespace_job_route:loki_request_duration_seconds:avg"
DEBU[0000] linting recording rule name                   rule="namespace_job_route:loki_request_duration_seconds_bucket:sum_rate"
DEBU[0000] linting recording rule name                   rule="namespace_job_route:loki_request_duration_seconds_sum:sum_rate"
DEBU[0000] linting recording rule name                   rule="namespace_job_route:loki_request_duration_seconds_count:sum_rate"
DEBU[0000] linting recording rule name                   rule="node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate"
```