### PR TITLE
loki: node_namespace_pod_container rule should be by node+namespace

### DIFF
--- a/loki/recording-rules.yaml
+++ b/loki/recording-rules.yaml
@@ -44,5 +44,5 @@ spec:
       record: namespace_job_route:loki_request_duration_seconds_sum:sum_rate
     - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (namespace, job, route)
       record: namespace_job_route:loki_request_duration_seconds_count:sum_rate
-    - expr: sum(rate(container_cpu_usage_seconds_total[1m])) by (pod, container)
+    - expr: sum(rate(container_cpu_usage_seconds_total[1m])) by (node, namespace, pod, container)
       record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate


### PR DESCRIPTION
The loki operational dashboard uses e.g. `node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace="loki", pod=~"distributor.*"}`
This is failing as the `namespace` label is missing from our recording rule.

I assume based on the rule name, it was supposed to be across node, namespace, pod, container. 