### PR TITLE
loki: allow querier engine timeout to be configured

### DIFF
--- a/loki/files/config.yaml
+++ b/loki/files/config.yaml
@@ -65,6 +65,7 @@ querier:
     # Must be a multiple of schema_config index.period
     # Default to 400 days retention.
     max_look_back_period: 9600h
+    timeout: ${LOKI_QUERIER_ENGINE_TIMEOUT:-3m}
   query_ingesters_within: 2h
   query_timeout: ${LOKI_QUERIER_QUERY_TIMEOUT:-60s}
 query_range:


### PR DESCRIPTION
New env var `LOKI_QUERIER_ENGINE_TIMEOUT`

This is the timeout for query execution, and probably want people want rather
than `LOKI_QUERIER_QUERY_TIMEOUT`, which is the timeout for the queriers
talking to ingesters/backing storage.