### PR TITLE
promtail: drop pods with no controller from direct-controller job

### DIFF
--- a/promtail/files/promtail.yaml
+++ b/promtail/files/promtail.yaml
@@ -156,6 +156,12 @@ scrape_configs:
         source_labels:
           - __meta_kubernetes_pod_label_app_kubernetes_io_name
           - __meta_kubernetes_pod_label_app
+      # Drop pods that have no controller
+      - action: drop
+        regex: ''
+        source_labels:
+          - __meta_kubernetes_pod_controller_name
+      # Drop pods that have an indirect controller
       - action: drop
         regex: '[0-9a-z-.]+-[0-9a-f]{8,10}'
         source_labels:


### PR DESCRIPTION
Currently pods with *no* controller are getting their logs picked up twice.
Once by kubernetes-pods-direct-controllers (unintentionally), and also by
kubernetes-other (intentionally).

This commit fixes the kubernetes-pods-direct-controllers job