### PR TITLE
Loki 2.4.1 release

### DIFF
--- a/loki-canary/kustomization.yaml
+++ b/loki-canary/kustomization.yaml
@@ -12,5 +12,5 @@ configMapGenerator:
       - files/dashboard.json
 images:
   - name: grafana/loki-canary
-    newTag: 2.3.0
-    digest: sha256:19922546f8d7a56112d417a9d88ba804ff6334294da201c31c72a705611e9fb7
+    newTag: 2.4.1
+    digest: sha256:4a57e141b0ffecfdee4dd4e929eab8bd184113e55f3101dca7544ae0de5da2c2

--- a/loki/apps-v1.StatefulSet-ingester.yaml
+++ b/loki/apps-v1.StatefulSet-ingester.yaml
@@ -34,7 +34,7 @@ spec:
         - -boltdb.shipper.cache-location=/data/boltdb-cache
         - -config.expand-env
         - -config.file=/etc/loki/config/config.yaml
-        - -ingester.max-transfer-retries=0
+        - -ingester.wal-dir=/loki/wal
         - -target=ingester
         envFrom:
         - configMapRef:
@@ -72,6 +72,8 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: ingester-data
+        - mountPath: /loki/wal
+          name: ingester-wal
         - mountPath: /etc/loki/config
           name: loki
       securityContext:
@@ -96,3 +98,11 @@ spec:
       resources:
         requests:
           storage: 10Gi
+  - metadata:
+      name: ingester-wal
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 150Gi

--- a/loki/files/config.yaml
+++ b/loki/files/config.yaml
@@ -10,10 +10,6 @@ chunk_store_config:
       service: memcached-client
 compactor:
   shared_store: aws
-distributor:
-  ring:
-    kvstore:
-      store: memberlist
 frontend:
   compress_responses: true
   log_queries_longer_than: 5s
@@ -33,8 +29,6 @@ ingester:
     num_tokens: 512
     ring:
       heartbeat_timeout: 1m
-      kvstore:
-        store: memberlist
       replication_factor: 3
   wal:
     # should be set upto ~50% of available memory
@@ -94,9 +88,6 @@ ruler:
     enabled: ${LOKI_RULER_REMOTE_WRITE_ENABLED:-false}
     client:
       url: ${LOKI_RULER_REMOTE_WRITE_CLIENT_URL:-""}
-  ring:
-    kvstore:
-      store: memberlist
   rule_path: /run/loki/ruler/scratch/
   storage:
     type: local

--- a/loki/files/config.yaml
+++ b/loki/files/config.yaml
@@ -36,7 +36,10 @@ ingester:
       kvstore:
         store: memberlist
       replication_factor: 3
-  max_transfer_retries: 60
+  wal:
+    # should be set upto ~50% of available memory
+    replay_memory_ceiling: ${LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING:-5GB}
+  max_transfer_retries: 0
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864

--- a/loki/ingress/ingress.yaml
+++ b/loki/ingress/ingress.yaml
@@ -50,6 +50,20 @@ spec:
             name: ruler
             port:
               number: 3100
+      - path: /prometheus/api/v1/alerts
+        pathType: Prefix
+        backend:
+          service:
+            name: ruler
+            port:
+              number: 3100
+      - path: /prometheus/api/v1/rules
+        pathType: Prefix
+        backend:
+          service:
+            name: ruler
+            port:
+              number: 3100
       - path: /loki/api
         pathType: Prefix
         backend:

--- a/loki/ingress/ingress.yaml
+++ b/loki/ingress/ingress.yaml
@@ -43,6 +43,13 @@ spec:
             name: querier
             port:
               number: 3100
+      - path: /loki/api/v1/rules
+        pathType: Prefix
+        backend:
+          service:
+            name: ruler
+            port:
+              number: 3100
       - path: /loki/api
         pathType: Prefix
         backend:

--- a/loki/kustomization.yaml
+++ b/loki/kustomization.yaml
@@ -43,8 +43,8 @@ configMapGenerator:
       - files/loki-operational-dashboard.json
 images:
   - name: grafana/loki
-    newTag: 2.3.0
-    digest: sha256:bbf6dbf3264af939a541b6f3c014cba21a2bdc8f22cb7962eee7e9048b41ea5e
+    newTag: 2.4.1
+    digest: sha256:1d802d29cf041601895ce16439757baf4dac71a21069957616ee7988746bf59c
   - name: memcached
     newTag: 1.6.10-alpine
     digest: sha256:34b1ab627355edd9cceaa422b7b91e57caf007ae9b1a22922c38a08660e81efb

--- a/loki/kustomization.yaml
+++ b/loki/kustomization.yaml
@@ -46,8 +46,8 @@ images:
     newTag: 2.4.1
     digest: sha256:1d802d29cf041601895ce16439757baf4dac71a21069957616ee7988746bf59c
   - name: memcached
-    newTag: 1.6.10-alpine
-    digest: sha256:34b1ab627355edd9cceaa422b7b91e57caf007ae9b1a22922c38a08660e81efb
+    newTag: 1.6.12-alpine
+    digest: sha256:3f7a5344127ef35b161215381f8ecf72d17896f2650ad0d253a9f77db7731b56
   - name: prom/memcached-exporter
     newTag: v0.9.0
     digest: sha256:bed44ac76ba3b62dc5c5ae342da85be4af83609b509a16f0b53630cd69bdb368

--- a/loki/ruler-sidecar/kustomization.yaml
+++ b/loki/ruler-sidecar/kustomization.yaml
@@ -6,5 +6,5 @@ patches:
   - path: ruler.patch.yaml
 images:
   - name: kiwigrid/k8s-sidecar
-    newTag: 1.12.2
-    digest: sha256:ca760f94b35eb78575b170e41d1e19e27359b29245dacfd1c42ae90452ecc08e
+    newTag: 1.14.2
+    digest: sha256:35654389f8a9b7816193a4811cf3ceb6cf309ece8874e84b3d2d8399e618059b

--- a/promtail/kustomization.yaml
+++ b/promtail/kustomization.yaml
@@ -21,5 +21,5 @@ configMapGenerator:
       - files/loki-promtail-dashboard.json
 images:
   - name: grafana/promtail
-    newTag: 2.3.0
-    digest: sha256:6cc13fe2f7cbae6ba19b3fbea04f38165f82dfe2070f99c5ef739d8ba80a9c8e
+    newTag: 2.4.1
+    digest: sha256:3b669d95e66f97e1ec3013d248d70a9da9768c1403e36d3bb69f12066cf2821b

--- a/promtail/kustomization.yaml
+++ b/promtail/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # Generated from promtail-2.0.1 helm chart
+  # Generated from promtail-3.8.2 helm chart
   ## persistence.enabled=true
   ## serviceMonitor.enabled=true
   ## tolerations[0].operator=Exists

--- a/promtail/resources.yaml
+++ b/promtail/resources.yaml
@@ -1,36 +1,3 @@
----
-# Source: promtail/templates/podsecuritypolicy.yaml
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: loki-promtail
-  labels:
-    app.kubernetes.io/name: promtail
-spec:
-  allowPrivilegeEscalation: false
-  fsGroup:
-    rule: RunAsAny
-  hostIPC: false
-  hostNetwork: false
-  hostPID: false
-  privileged: false
-  readOnlyRootFilesystem: true
-  requiredDropCapabilities:
-  - ALL
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-  - secret
-  - configMap
-  - hostPath
-  - projected
-  - downwardAPI
-  - emptyDir
----
 # Source: promtail/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -70,34 +37,6 @@ roleRef:
   kind: ClusterRole
   name: loki-promtail-clusterrole
   apiGroup: rbac.authorization.k8s.io
----
-# Source: promtail/templates/role.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: loki-promtail
-  labels:
-    app.kubernetes.io/name: promtail
-rules:
-- apiGroups:      ['extensions']
-  resources:      ['podsecuritypolicies']
-  verbs:          ['use']
-  resourceNames:  [loki-promtail]
----
-# Source: promtail/templates/rolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: loki-promtail
-  labels:
-    app.kubernetes.io/name: promtail
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: loki-promtail
-subjects:
-- kind: ServiceAccount
-  name: loki-promtail
 ---
 # Source: promtail/templates/service-headless.yaml
 apiVersion: v1

--- a/promtail/resources.yaml
+++ b/promtail/resources.yaml
@@ -2,32 +2,36 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: loki-promtail
   labels:
     app.kubernetes.io/name: promtail
-  name: loki-promtail
 ---
 # Source: promtail/templates/clusterrole.yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: loki-promtail
   labels:
     app.kubernetes.io/name: promtail
-  name: loki-promtail-clusterrole
 rules:
-- apiGroups: [""] # "" indicates the core API group
-  resources:
-  - nodes
-  - nodes/proxy
-  - services
-  - endpoints
-  - pods
-  verbs: ["get", "watch", "list"]
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - watch
+      - list
 ---
 # Source: promtail/templates/clusterrolebinding.yaml
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: loki-promtail-clusterrolebinding
+  name: loki-promtail
   labels:
     app.kubernetes.io/name: promtail
 subjects:
@@ -35,23 +39,23 @@ subjects:
     name: loki-promtail
 roleRef:
   kind: ClusterRole
-  name: loki-promtail-clusterrole
+  name: loki-promtail
   apiGroup: rbac.authorization.k8s.io
 ---
 # Source: promtail/templates/service-headless.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: loki-promtail-headless
+  name: loki-promtail-metrics
   labels:
     app.kubernetes.io/name: promtail
 spec:
   clusterIP: None
   ports:
-    - port: 3101
-      protocol: TCP
-      name: http-metrics
+    - name: http-metrics
+      port: 3101
       targetPort: http-metrics
+      protocol: TCP
   selector:
     app.kubernetes.io/name: promtail
 ---
@@ -66,12 +70,17 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: promtail
+  updateStrategy:
+    {}
   template:
     metadata:
       labels:
         app.kubernetes.io/name: promtail
     spec:
       serviceAccountName: loki-promtail
+      securityContext:
+        runAsGroup: 0
+        runAsUser: 0
       containers:
         - name: promtail
           image: grafana/promtail
@@ -101,16 +110,19 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 3101
-              name: http-metrics
+            - name: http-metrics
+              containerPort: 3101
+              protocol: TCP
           resources:
             requests:
               cpu: 100m
               memory: 75Mi
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
-            runAsGroup: 0
-            runAsUser: 0
           readinessProbe:
             failureThreshold: 5
             httpGet:
@@ -156,4 +168,4 @@ spec:
     matchLabels:
       app.kubernetes.io/name: promtail
   endpoints:
-  - port: http-metrics
+    - port: http-metrics


### PR DESCRIPTION
Release Notes:
  - https://github.com/grafana/loki/releases/tag/v2.4.0
  - https://github.com/grafana/loki/releases/tag/v2.4.1

Upgrade notes: https://github.com/grafana/loki/blob/90d5d24998e44e9c0bdb0517a9d518f29b72a75b/docs/sources/upgrading/_index.md#240

  - Enable ingester WAL
  - Out-of-order writes is [now on by default](https://github.com/grafana/loki/blob/e52e8051447726f69d426df3f79fac3cb1384524/docs/sources/configuration/_index.md#accept-out-of-order-writes)

Replaces #26 