### PR TITLE
loki: add ruler wal dir path

### DIFF
--- a/loki/apps-v1.StatefulSet-ruler.yaml
+++ b/loki/apps-v1.StatefulSet-ruler.yaml
@@ -33,6 +33,7 @@ spec:
         - -config.expand-env
         - -config.file=/etc/loki/config/config.yaml
         - -target=ruler
+        - -ruler.wal.dir=/data/ruler-wal
         envFrom:
         - configMapRef:
             name: loki-env-vars


### PR DESCRIPTION
Without this you get errors such as:
> level=error ts=2021-11-09T22:20:31.707029751Z caller=manager.go:269 storage=registry manager=tenant-wal msg="instance stopped abnormally, restarting after backoff period" err="failed to initialize instance: error creating WAL: create dir: mkdir ruler-wal: read-only file system" backoff=1s instance=fake