### PR TITLE
loki: use serviceAccountName rather than serviceAccount

### DIFF
--- a/loki/apps-v1.StatefulSet-compactor.yaml
+++ b/loki/apps-v1.StatefulSet-compactor.yaml
@@ -60,7 +60,7 @@ spec:
         runAsGroup: 10001
         runAsNonRoot: true
         runAsUser: 10001
-      serviceAccount: loki
+      serviceAccountName: loki
       volumes:
       - configMap:
           name: loki

--- a/loki/apps-v1.StatefulSet-ingester.yaml
+++ b/loki/apps-v1.StatefulSet-ingester.yaml
@@ -81,7 +81,7 @@ spec:
         runAsGroup: 10001
         runAsNonRoot: true
         runAsUser: 10001
-      serviceAccount: loki
+      serviceAccountName: loki
       terminationGracePeriodSeconds: 4800
       volumes:
       - configMap:

--- a/loki/apps-v1.StatefulSet-querier.yaml
+++ b/loki/apps-v1.StatefulSet-querier.yaml
@@ -74,7 +74,7 @@ spec:
         runAsGroup: 10001
         runAsNonRoot: true
         runAsUser: 10001
-      serviceAccount: loki
+      serviceAccountName: loki
       volumes:
       - configMap:
           name: loki

--- a/loki/apps-v1.StatefulSet-ruler.yaml
+++ b/loki/apps-v1.StatefulSet-ruler.yaml
@@ -79,7 +79,7 @@ spec:
         runAsGroup: 10001
         runAsNonRoot: true
         runAsUser: 10001
-      serviceAccount: loki
+      serviceAccountName: loki
       volumes:
       - configMap:
           name: loki

--- a/loki/index-gateway/apps-v1.StatefulSet-index-gateway.yaml
+++ b/loki/index-gateway/apps-v1.StatefulSet-index-gateway.yaml
@@ -57,7 +57,7 @@ spec:
         runAsGroup: 10001
         runAsNonRoot: true
         runAsUser: 10001
-      serviceAccount: loki
+      serviceAccountName: loki
       volumes:
       - configMap:
           name: loki


### PR DESCRIPTION
kustomize only understands name references if you use `serviceAccountName`
https://github.com/kubernetes-sigs/kustomize/blob/e5041bae6f3b536b764f96c1cf72d332a9c68c43/api/konfig/builtinpluginconsts/namereference.go#L349