### PR TITLE
promtail: update eventrouter label support

### DIFF
--- a/promtail/files/promtail.yaml
+++ b/promtail/files/promtail.yaml
@@ -11,6 +11,18 @@ scrape_configs:
   - job_name: kubernetes-pods-app-kubernetes-io-name
     pipeline_stages:
       - docker: {}
+      - match:
+          selector: '{app="eventrouter",stream="stdout"}'
+          stages:
+            - json:
+                expressions:
+                  namespace: event.metadata.namespace
+                  ts: event.lastTimestamp
+            - labels:
+                namespace: ""
+            - timestamp:
+                format: RFC3339
+                source: ts
     kubernetes_sd_configs:
       - role: pod
     relabel_configs:


### PR DESCRIPTION
Support both kubernetes recommended labels and legacy labels.
https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

Previously 'app' was used as the standard label for an application
name label. Many projects are now using the above recommended labels
so this commit supports both approaches.
