### PR TITLE
loki: reduce sensitivity of query latency alert

### DIFF
--- a/loki/alerting-rules.yaml
+++ b/loki/alerting-rules.yaml
@@ -34,7 +34,7 @@ spec:
               {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
           expr: |
             namespace_job_route:loki_request_duration_seconds:99quantile{route!~"(?i).*tail.*"} > 1
-          for: 15m
+          for: 30m
           labels:
             severity: critical
         - alert: LokiTooManyCompactorsRunning


### PR DESCRIPTION
This alert is a little bit too noisy and could benefit from being
monitored over a longer period.

Closes #64
