### PR TITLE
Don't alert on 0-length files that aren't being read.

### DIFF
--- a/promtail/alerting-rules.yaml
+++ b/promtail/alerting-rules.yaml
@@ -43,7 +43,7 @@ spec:
           message: |
             {{ $labels.instance }} {{ $labels.job }} {{ $labels.path }} matches the glob but is not being tailed.
         expr: |
-          promtail_file_bytes_total unless promtail_read_bytes_total
+          (promtail_file_bytes_total unless promtail_read_bytes_total) > 0
         for: 15m
         labels:
           severity: critical


### PR DESCRIPTION
Usually 0-length files are short-lived and are filtered by the `for: 15m`. However, in rare occasions they can live long enough to cause a false alarm. Filtering them out prevents this.