### PR TITLE
add cri stage to promtail

### DIFF
--- a/promtail/files/promtail.yaml
+++ b/promtail/files/promtail.yaml
@@ -9,7 +9,7 @@ scrape_configs:
   # Pods with a label 'app.kubernetes.io/name'
   - job_name: kubernetes-pods-app-kubernetes-io-name
     pipeline_stages:
-      - docker: {}
+      - cri: {}
       - match:
           selector: '{app="eventrouter",stream="stdout"}'
           stages:
@@ -88,7 +88,7 @@ scrape_configs:
   # Pods with a label 'app'
   - job_name: kubernetes-pods-app
     pipeline_stages:
-      - docker: {}
+      - cri: {}
       - match:
           selector: '{app="eventrouter",stream="stdout"}'
           stages:
@@ -172,7 +172,7 @@ scrape_configs:
   # Pods with direct controllers, such as StatefulSet
   - job_name: kubernetes-pods-direct-controllers
     pipeline_stages:
-      - docker: {}
+      - cri: {}
       - labeldrop:
           - filename      
     kubernetes_sd_configs:
@@ -248,7 +248,7 @@ scrape_configs:
   # Pods with indirect controllers, such as Deployment
   - job_name: kubernetes-pods-indirect-controller
     pipeline_stages:
-      - docker: {}
+      - cri: {}
       - labeldrop:
           - filename      
     kubernetes_sd_configs:
@@ -319,7 +319,7 @@ scrape_configs:
   # All remaining pods not yet covered
   - job_name: kubernetes-other
     pipeline_stages:
-      - docker: {}
+      - cri: {}
       - labeldrop:
           - filename
     kubernetes_sd_configs:


### PR DESCRIPTION
Containerd logs are in `cri` format instead of `docker`, so we have to change the promtail ingestion format.

Ticket: BG-76807