### PR TITLE
bump loki images v2.8.4

### DIFF
--- a/loki-canary/kustomization.yaml
+++ b/loki-canary/kustomization.yaml
@@ -12,5 +12,5 @@ configMapGenerator:
       - files/dashboard.json
 images:
   - name: grafana/loki-canary
-    newTag: 2.8.2
-    digest: sha256:9fe1b8bbfebc9820486c54eb2812401b5a077e3725933d8e9c2be03f96d20c5e
+    newTag: 2.8.4
+    digest: sha256:6a75ff46cf84ef70076d9f7d4dcad02d61ba934f018bb3479f018d02386ffafb

--- a/loki/kustomization.yaml
+++ b/loki/kustomization.yaml
@@ -45,8 +45,8 @@ configMapGenerator:
       - files/loki-operational-dashboard.json
 images:
   - name: grafana/loki
-    newTag: 2.8.2
-    digest: sha256:b1da1d23037eb1b344cccfc5b587e30aed60ab4cad33b42890ff850aa3c4755d
+    newTag: 2.8.4
+    digest: sha256:621788d5469cc822977a5ace9c91f8ba1ad0fadd7b4cfdab26af9e64c2025ce2
   - name: memcached
     newTag: 1.6.20-alpine
     digest: sha256:d3c874bf086273517be596ea99d16a01112211b65d4f403369696f7f372fa35a

--- a/promtail/kustomization.yaml
+++ b/promtail/kustomization.yaml
@@ -21,5 +21,5 @@ configMapGenerator:
       - files/loki-promtail-dashboard.json
 images:
   - name: grafana/promtail
-    newTag: 2.8.2
-    digest: sha256:762bc5be21174c50c636cf53e4c94bacf940488a803edb3e3018f6d0dd09df57
+    newTag: 2.8.4
+    digest: sha256:67f60160f2d65f37f0a457109bfb5bd456ec630b7c29a399cd3ef6ae80048469


### PR DESCRIPTION
- loki: bump docker images to v2.8.4
- loki-canary: bump docker images to v2.8.4
- promtail: bump docker images to v2.8.4

Closes #72
