### PR TITLE
loki: tune cpu requests based on prod-like usage

### DIFF
--- a/loki/apps-v1.Deployment-query-frontend.yaml
+++ b/loki/apps-v1.Deployment-query-frontend.yaml
@@ -57,7 +57,7 @@ spec:
           limits:
             memory: 6Gi
           requests:
-            cpu: "2"
+            cpu: 2
             memory: 2Gi
         securityContext:
           allowPrivilegeEscalation: false

--- a/loki/apps-v1.Deployment-query-scheduler.yaml
+++ b/loki/apps-v1.Deployment-query-scheduler.yaml
@@ -57,7 +57,7 @@ spec:
           limits:
             memory: 1200Mi
           requests:
-            cpu: "2"
+            cpu: 1
             memory: 600Mi
         securityContext:
           allowPrivilegeEscalation: false

--- a/loki/apps-v1.StatefulSet-compactor.yaml
+++ b/loki/apps-v1.StatefulSet-compactor.yaml
@@ -43,7 +43,7 @@ spec:
           timeoutSeconds: 1
         resources:
           requests:
-            cpu: "4"
+            cpu: 2
             memory: 2Gi
         securityContext:
           allowPrivilegeEscalation: false

--- a/loki/apps-v1.StatefulSet-ingester.yaml
+++ b/loki/apps-v1.StatefulSet-ingester.yaml
@@ -61,7 +61,7 @@ spec:
           limits:
             memory: 10Gi
           requests:
-            cpu: "1"
+            cpu: 1
             memory: 5Gi
         securityContext:
           allowPrivilegeEscalation: false

--- a/loki/apps-v1.StatefulSet-querier.yaml
+++ b/loki/apps-v1.StatefulSet-querier.yaml
@@ -57,7 +57,7 @@ spec:
           timeoutSeconds: 1
         resources:
           requests:
-            cpu: "4"
+            cpu: 2
             memory: 2Gi
         securityContext:
           allowPrivilegeEscalation: false

--- a/loki/apps-v1.StatefulSet-ruler.yaml
+++ b/loki/apps-v1.StatefulSet-ruler.yaml
@@ -51,7 +51,7 @@ spec:
           name: memberlist
         resources:
           requests:
-            cpu: "1"
+            cpu: 1
             memory: 6Gi
           limits:
             memory: 16Gi


### PR DESCRIPTION
Observing several months of prod-like usage shows that some of the
components are a bit over provisioned and can benefit from some
reduction in requests.
